### PR TITLE
Serializable in generated classes

### DIFF
--- a/ladok3-dto/pom.xml
+++ b/ladok3-dto/pom.xml
@@ -43,8 +43,10 @@
               <sourceRoot>${basedir}/target/generated/src/main/java</sourceRoot>
               <xsdOptions>
                 <xsdOption>
+                  <extension>true</extension>
                   <!-- Schemas and doc found @ https://www.mit.ladok.se/restdoc/ -->
                   <xsdDir>${basedir}/src/main/resources/xsd-rest/</xsdDir>
+                  <bindingFile>${basedir}/src/main/resources/bindings.xml</bindingFile>
                   <extensionArgs>
                     <!-- No header, easier to diff -->
                     <extensionArg>-no-header</extensionArg>
@@ -56,8 +58,10 @@
                   </extensionArgs>
                 </xsdOption>
                 <xsdOption>
+                  <extension>true</extension>
                   <!-- Schemas and doc found @ https://www.mit.ladok.se/restdoc/ -->
                   <xsdDir>${basedir}/src/main/resources/xsd-atom/</xsdDir>
+                  <bindingFile>${basedir}/src/main/resources/bindings.xml</bindingFile>
                   <extensionArgs>
                     <!-- No header, easier to diff -->
                     <extensionArg>-no-header</extensionArg>

--- a/ladok3-dto/pom.xml
+++ b/ladok3-dto/pom.xml
@@ -43,7 +43,6 @@
               <sourceRoot>${basedir}/target/generated/src/main/java</sourceRoot>
               <xsdOptions>
                 <xsdOption>
-                  <extension>true</extension>
                   <!-- Schemas and doc found @ https://www.mit.ladok.se/restdoc/ -->
                   <xsdDir>${basedir}/src/main/resources/xsd-rest/</xsdDir>
                   <bindingFile>${basedir}/src/main/resources/bindings.xml</bindingFile>
@@ -55,10 +54,10 @@
                     <arg>-encoding</arg>
                     <arg>UTF-8</arg>
                     <arg>-npa</arg>
+                    <arg>-extension</arg>
                   </extensionArgs>
                 </xsdOption>
                 <xsdOption>
-                  <extension>true</extension>
                   <!-- Schemas and doc found @ https://www.mit.ladok.se/restdoc/ -->
                   <xsdDir>${basedir}/src/main/resources/xsd-atom/</xsdDir>
                   <bindingFile>${basedir}/src/main/resources/bindings.xml</bindingFile>
@@ -70,6 +69,7 @@
                     <arg>-encoding</arg>
                     <arg>UTF-8</arg>
                     <arg>-npa</arg>
+                    <arg>-extension</arg>
                   </extensionArgs>
                 </xsdOption>
               </xsdOptions>

--- a/ladok3-dto/src/main/resources/bindings.xml
+++ b/ladok3-dto/src/main/resources/bindings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jaxb:bindings
+        xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+        xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+        jaxb:version="2.1">
+    <jaxb:globalBindings>
+        <xjc:serializable uid="-1"/>
+    </jaxb:globalBindings>
+</jaxb:bindings>


### PR DESCRIPTION
In order to use the generated classes in scenarios where the java classes are required to implement Serializable (like in a JMS scenario), I have added this to the class declarations.